### PR TITLE
💄 ui: change the header title only for the team dashboard page

### DIFF
--- a/src/views/TeamView.vue
+++ b/src/views/TeamView.vue
@@ -86,9 +86,8 @@ const deleteMember = (id) => {
 </script>
 
 <template>
-    <Header />
+    <Header title="Manage your team!" />
     <div class="flex flex-col items-center justify-center gap-2">
-        <h1 class="text-3xl m-5">Manage your team!</h1>
         <FormField
             @update:value="teamOnChange"
             id="teamname"


### PR DESCRIPTION
Display "Manage your team" instead of the actual team name.